### PR TITLE
test: enable mb04rd tests on Linux

### DIFF
--- a/tests/python/test_mb04rd.py
+++ b/tests/python/test_mb04rd.py
@@ -8,12 +8,8 @@ The transformations are bounded by PMAX and optionally accumulated in X and Y.
 Optionally reorders diagonal blocks so clustered eigenvalues are grouped.
 """
 
-import sys
-
 import numpy as np
 import pytest
-
-pytestmark = pytest.mark.skipif(sys.platform == 'linux', reason='OpenBLAS memory corruption')
 
 from slicot import mb04rd
 


### PR DESCRIPTION
## Summary
- Remove Linux skip for mb04rd tests (memory corruption was fixed)

## Test plan
- CI will run mb04rd tests on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)