### PR TITLE
fix: ab01md uninitialized Z for n=1, make CI openblas install optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
           CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2
-          CIBW_BEFORE_ALL_LINUX: (dnf install -y openblas-devel 2>/dev/null || yum install -y openblas-devel) || apk add openblas-dev
+          CIBW_BEFORE_ALL_LINUX: (dnf install -y openblas-devel 2>/dev/null || yum install -y openblas-devel 2>/dev/null || apk add openblas-dev 2>/dev/null) || true
           CIBW_BEFORE_ALL_WINDOWS: choco install -y pkgconfiglite
           CIBW_ENVIRONMENT_LINUX: PKG_CONFIG_PATH=/tmp/openblas
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0 PKG_CONFIG_PATH=/tmp/openblas

--- a/src/AB/ab01md.c
+++ b/src/AB/ab01md.c
@@ -122,6 +122,9 @@ void ab01md(const char* jobz, i32 n, f64* a, i32 lda, f64* b, i32* ncont,
                 SLC_DLACPY("L", &nm2, &nm2, &a[2], &lda, &z[2 + ldz], &ldz);
             }
             if (ljobi) {
+                if (n == 1) {
+                    z[0] = ONE;
+                }
                 SLC_DORGQR(&n, &n, &n, z, &ldz, tau, dwork, &ldwork, &info_tmp);
                 f64 newopt = dwork[0];
                 wrkopt = (wrkopt > newopt) ? wrkopt : newopt;


### PR DESCRIPTION
## Summary
- Fix ab01md returning garbage for n=1 case on Windows (uninitialized Z array)
- Make CIBW_BEFORE_ALL_LINUX optional since scipy-openblas32 provides OpenBLAS

## Root cause
1. **Windows test failure**: `test_n_equals_1` returned `4.43e+281` - Z array was never initialized before DORGQR call when n=1
2. **Ubuntu aarch64 build failure**: `dnf`/`yum`/`apk` commands failed with code 127; not needed since scipy-openblas32 is used

## Test plan
- [x] Windows build passes
- [x] Ubuntu aarch64 build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)